### PR TITLE
fix(report-summary): multiply Developer Proceeds by Units in sales summary

### DIFF
--- a/Sources/asc-mcp/Helpers/ReportSummary.swift
+++ b/Sources/asc-mcp/Helpers/ReportSummary.swift
@@ -47,9 +47,12 @@ enum ReportSummary {
             totalUnits += units
 
             let currency = row["Currency of Proceeds"] ?? row["Customer Currency"] ?? ""
-            let proceeds = Double(row["Developer Proceeds"] ?? "") ?? 0.0
+            // Apple's SALES report `Developer Proceeds` column is per-unit, not the row total.
+            // Multiply by Units to get the row's contribution to total proceeds.
+            let proceedsPerUnit = Double(row["Developer Proceeds"] ?? "") ?? 0.0
+            let rowProceeds = proceedsPerUnit * Double(units)
             if !currency.isEmpty {
-                proceedsByCurrency[currency, default: 0.0] += proceeds
+                proceedsByCurrency[currency, default: 0.0] += rowProceeds
             }
 
             let country = row["Country Code"] ?? ""
@@ -65,7 +68,7 @@ enum ReportSummary {
             let title = row["Title"] ?? ""
             if !title.isEmpty {
                 appStats[title, default: AppSalesStats()].units += units
-                appStats[title, default: AppSalesStats()].proceedsByCurrency[currency, default: 0.0] += proceeds
+                appStats[title, default: AppSalesStats()].proceedsByCurrency[currency, default: 0.0] += rowProceeds
             }
         }
 
@@ -247,9 +250,12 @@ enum ReportSummary {
             }
 
             let currency = row["Proceeds Currency"] ?? row["Customer Currency"] ?? ""
-            let proceeds = Double(row["Developer Proceeds"] ?? "") ?? 0.0
+            // Apple's SUBSCRIBER report `Developer Proceeds` is per-unit; multiply by Units
+            // to get the row total (typically Units=1 per row, but be defensive).
+            let proceedsPerUnit = Double(row["Developer Proceeds"] ?? "") ?? 0.0
+            let rowProceeds = proceedsPerUnit * Double(units)
             if !currency.isEmpty {
-                proceedsByCurrency[currency, default: 0.0] += proceeds
+                proceedsByCurrency[currency, default: 0.0] += rowProceeds
             }
 
             let country = row["Country"] ?? ""

--- a/Tests/ASCMCPTests/HelperTests/ReportSummaryTests.swift
+++ b/Tests/ASCMCPTests/HelperTests/ReportSummaryTests.swift
@@ -25,15 +25,46 @@ struct ReportSummaryTests {
     }
 
     @Test func salesSummary_proceedsByCurrency() {
+        // Apple's `Developer Proceeds` column is per-unit. Each row represents `Units`
+        // sales at `Developer Proceeds` each, so the row's contribution to the total is
+        // Units × Developer Proceeds.
         let rows: [[String: String]] = [
-            ["Units": "10", "Developer Proceeds": "69.90", "Currency of Proceeds": "USD"],
-            ["Units": "5", "Developer Proceeds": "34.95", "Currency of Proceeds": "EUR"],
-            ["Units": "3", "Developer Proceeds": "20.10", "Currency of Proceeds": "USD"]
+            ["Units": "10", "Developer Proceeds": "6.99", "Currency of Proceeds": "USD"],
+            ["Units": "5",  "Developer Proceeds": "6.99", "Currency of Proceeds": "EUR"],
+            ["Units": "3",  "Developer Proceeds": "6.70", "Currency of Proceeds": "USD"]
         ]
         let summary = ReportSummary.salesSummary(from: rows)
         let proceeds = summary["proceeds_by_currency"] as? [String: Double]
+        // USD: 10 × 6.99 + 3 × 6.70 = 69.90 + 20.10 = 90.00
         #expect(proceeds?["USD"] == 90.0)
+        // EUR: 5 × 6.99 = 34.95
         #expect(proceeds?["EUR"] == 34.95)
+    }
+
+    @Test func salesSummary_proceedsScalesWithUnits() {
+        // Regression test: previously `Developer Proceeds` was summed directly,
+        // ignoring `Units`, which undercounted multi-unit rows.
+        let rows: [[String: String]] = [
+            // 100 sales at $0.70 each in one aggregated row.
+            ["Units": "100", "Developer Proceeds": "0.70", "Currency of Proceeds": "USD"]
+        ]
+        let summary = ReportSummary.salesSummary(from: rows)
+        let proceeds = summary["proceeds_by_currency"] as? [String: Double]
+        #expect(proceeds?["USD"] == 70.0) // 100 × 0.70, not 0.70
+    }
+
+    @Test func salesSummary_perAppProceedsScalesWithUnits() {
+        // Same regression for the per-app breakdown (by_app).
+        let rows: [[String: String]] = [
+            ["Title": "MyApp", "Units": "10", "Developer Proceeds": "0.70", "Currency of Proceeds": "USD"],
+            ["Title": "MyApp", "Units": "5",  "Developer Proceeds": "0.62", "Currency of Proceeds": "EUR"]
+        ]
+        let summary = ReportSummary.salesSummary(from: rows)
+        let byApp = summary["by_app"] as? [[String: Any]]
+        #expect(byApp?.count == 1)
+        let stats = byApp?.first?["proceeds_by_currency"] as? [String: Double]
+        #expect(stats?["USD"] == 7.0)  // 10 × 0.70
+        #expect(stats?["EUR"] == 3.10) // 5 × 0.62
     }
 
     @Test func salesSummary_topCountries() {
@@ -65,6 +96,7 @@ struct ReportSummaryTests {
     }
 
     @Test func salesSummary_proceedsRounding() {
+        // Each row has Units=1 so row proceeds == per-unit proceeds.
         let rows: [[String: String]] = [
             ["Units": "1", "Developer Proceeds": "1.111", "Currency of Proceeds": "USD"],
             ["Units": "1", "Developer Proceeds": "2.222", "Currency of Proceeds": "USD"]


### PR DESCRIPTION
## Summary

Fixes a bug in `ReportSummary.salesSummary` (and the symmetric path in `subscriberSummary`) where `Developer Proceeds` was summed without multiplying by `Units`, causing total proceeds to be undercounted by a factor equal to the average Units-per-row.

## The bug

Apple's SALES report aggregates transactions by `[Country Code, Product Type, Customer Price, ...]`, producing rows like:

| Country | Currency | Units | Customer Price | Developer Proceeds |
|---|---|---|---|---|
| FR | EUR | 41 | 1.99 | **1.41** |
| GB | GBP | 10 | 0.99 | **0.70** |

`Developer Proceeds` is the per-unit amount the developer receives. The row's contribution to total proceeds is `Units × Developer Proceeds`, **not** `Developer Proceeds` alone.

The current code on `develop` (`ReportSummary.swift:52` and `:68`):

```swift
let proceeds = Double(row["Developer Proceeds"] ?? "") ?? 0.0
if !currency.isEmpty {
    proceedsByCurrency[currency, default: 0.0] += proceeds   // ← missing × units
}
```

## Impact

Real-world example from an app with ~$650 in monthly proceeds:

| | Tool reports (buggy) | Actual |
|---|---:|---:|
| Total proceeds (USD eq.) | $114.63 | **$651.67** |

About **5.7× undercount**. The factor depends on the average Units-per-row in the dataset, which is roughly proportional to a row's homogeneity — e.g. a single price tier in one country with many sales will have very high Units, magnifying the undercount.

The bug is not visible to anyone who only looks at `total_units`, `by_product_type`, or `top_countries` (those use `units` correctly). It only affects `proceeds_by_currency` (both top-level and inside each `by_app` entry).

## The fix

In `salesSummary`:

```swift
let proceedsPerUnit = Double(row["Developer Proceeds"] ?? "") ?? 0.0
let rowProceeds = proceedsPerUnit * Double(units)
proceedsByCurrency[currency, default: 0.0] += rowProceeds
```

Same treatment applied to the per-app accumulator (`appStats[...].proceedsByCurrency`) and to `subscriberSummary` for symmetry (SUBSCRIBER rows are typically `Units=1`, so this is mostly defensive).

`financialSummary` is **not** affected — it uses `Partner Share`, which Apple already provides as the row total.

## Tests

- `salesSummary_proceedsByCurrency`: previously asserted the buggy values (it summed *per-unit* amounts, which made the test pass even though the production behaviour was wrong). Updated to assert `Units × Developer Proceeds`.
- **New** `salesSummary_proceedsScalesWithUnits`: regression test with a single `Units=100` row that would catch any reintroduction of the bug.
- **New** `salesSummary_perAppProceedsScalesWithUnits`: same regression for the `by_app` path.

All 24 tests in `ReportSummary Tests` pass on this branch (`swift test --filter ReportSummaryTests`).

## How to verify against real data

After applying this fix and calling `analytics_sales_report` with `summary_only: true`, the `proceeds_by_currency` should now match what you get by manually computing `sum(Units × Developer Proceeds) per currency` from the raw rows (which is also what App Store Connect's "Sales and Trends" dashboard displays in your home currency, modulo FX).
