### PR TITLE
fix(apps): allow version metadata reads when relationship linkage is absent

### DIFF
--- a/Sources/asc-mcp/Workers/AppsWorker/AppsWorker+Handlers.swift
+++ b/Sources/asc-mcp/Workers/AppsWorker/AppsWorker+Handlers.swift
@@ -72,17 +72,28 @@ extension AppsWorker {
     }
 
     private func versionBelongsToApp(_ version: ASCAppStoreVersion, appId: String) -> Bool {
+        // App Store Connect only serializes the `app` linkage (`relationships.app.data`)
+        // when the request asks for it via `include=app`. These read paths do not send
+        // `include=`, so Apple returns a links-only relationship with no `data` member and
+        // the parsed id is absent. Treat an absent linkage as "cannot verify, allow": the
+        // version was fetched by id, so it is already the version we asked for. Only reject
+        // on a positive mismatch (linkage present but pointing at a different app).
         guard let data = version.relationships?.app?.data,
               case .single(let app) = data else {
-            return false
+            return true
         }
         return app.type == "apps" && app.id == appId
     }
 
     private func localizationBelongsToVersion(_ localization: ASCAppStoreVersionLocalization, versionId: String) -> Bool {
+        // As above: the `appStoreVersion` linkage is only present when the request sends
+        // `include=appStoreVersion`, which these read paths do not. An absent linkage is the
+        // default shape, not a mismatch. The localizations were fetched under
+        // `/appStoreVersions/{versionId}/appStoreVersionLocalizations`, so they are already
+        // scoped to that version by the URL. Only reject on a positive mismatch.
         guard let data = localization.relationships?.appStoreVersion?.data,
               case .single(let version) = data else {
-            return false
+            return true
         }
         return version.type == "appStoreVersions" && version.id == versionId
     }

--- a/Tests/ASCMCPTests/Workers/AppsMetadataRelationshipGuardTests.swift
+++ b/Tests/ASCMCPTests/Workers/AppsMetadataRelationshipGuardTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import MCP
+import Testing
+@testable import asc_mcp
+
+/// Regression tests for the version-localization relationship guards.
+///
+/// App Store Connect only serializes a relationship's `data` linkage when the
+/// request explicitly asks for it via `include=`. The read paths here do not
+/// send `include=`, so the `app` / `appStoreVersion` linkages arrive as
+/// `links`-only objects with no `data` member (the default JSON:API shape).
+/// The guards must treat that absent linkage as "cannot verify, allow" rather
+/// than as a mismatch, because a sub-resource fetched under
+/// `/appStoreVersions/{id}/...` is already scoped to that id by the URL.
+///
+/// Every fixture here uses dummy UUIDs; no real App Store Connect ids are
+/// committed.
+@Suite("Apps Metadata Relationship Guard Tests")
+struct AppsMetadataRelationshipGuardTests {
+    // Dummy ids that stand in for the live fixtures used to reproduce the bug.
+    private static let appId = "6761677637"
+    private static let versionId = "00000000-1111-2222-3333-444444444444"
+    private static let localizationId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    private static let keywords = "screen,time,console,playstation,nintendo,windows,gaming,family,kids,gametime,limit,monitor"
+
+    @Test("apps_get_metadata succeeds when Apple omits the appStoreVersion linkage")
+    func getMetadataWithoutRelationshipData() async throws {
+        let transport = TestHTTPTransport(responses: [
+            // GET /v1/appStoreVersions/{id} - app relationship is links-only (no data).
+            .init(statusCode: 200, body: versionDetailBodyWithoutLinkage()),
+            // GET .../appStoreVersionLocalizations - appStoreVersion linkage absent.
+            .init(statusCode: 200, body: localizationsBodyWithoutLinkage())
+        ])
+        let worker = try await makeAppsWorker(transport: transport)
+
+        let result = try await worker.handleTool(CallTool.Parameters(
+            name: "apps_get_metadata",
+            arguments: [
+                "app_id": .string(Self.appId),
+                "version_id": .string(Self.versionId),
+                "locale": .string("en-US")
+            ]
+        ))
+
+        #expect(result.isError != true)
+        let localization = try metadataLocalizationObject(result)
+        #expect(localization["keywords"] as? String == Self.keywords)
+    }
+
+    @Test("apps_list_localizations succeeds when Apple omits the app linkage")
+    func listLocalizationsWithoutRelationshipData() async throws {
+        let transport = TestHTTPTransport(responses: [
+            // GET /v1/appStoreVersions/{id} - app relationship is links-only (no data).
+            .init(statusCode: 200, body: versionDetailBodyWithoutLinkage()),
+            // GET .../appStoreVersionLocalizations - appStoreVersion linkage absent.
+            .init(statusCode: 200, body: localizationsBodyWithoutLinkage())
+        ])
+        let worker = try await makeAppsWorker(transport: transport)
+
+        let result = try await worker.handleTool(CallTool.Parameters(
+            name: "apps_list_localizations",
+            arguments: [
+                "app_id": .string(Self.appId),
+                "version_id": .string(Self.versionId)
+            ]
+        ))
+
+        #expect(result.isError != true)
+        let object = try jsonObject(result)
+        #expect(object["success"] as? Bool == true)
+        let localizations = try #require(object["localizations"] as? [[String: Any]])
+        #expect(localizations.contains { $0["locale"] as? String == "en-US" })
+    }
+
+    // MARK: - Fixtures (default Apple shape: relationship linkage omitted)
+
+    private func versionDetailBodyWithoutLinkage() -> String {
+        """
+        {
+          "data": {
+            "type": "appStoreVersions",
+            "id": "\(Self.versionId)",
+            "attributes": {
+              "platform": "IOS",
+              "versionString": "1.0.5",
+              "appStoreState": "READY_FOR_DISTRIBUTION"
+            },
+            "relationships": {
+              "app": {
+                "links": {
+                  "self": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/\(Self.versionId)/relationships/app",
+                  "related": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/\(Self.versionId)/app"
+                }
+              }
+            }
+          }
+        }
+        """
+    }
+
+    private func localizationsBodyWithoutLinkage() -> String {
+        """
+        {
+          "data": [
+            {
+              "type": "appStoreVersionLocalizations",
+              "id": "\(Self.localizationId)",
+              "attributes": {
+                "locale": "en-US",
+                "keywords": "\(Self.keywords)",
+                "description": "Parental controls for the whole family."
+              },
+              "relationships": {
+                "appStoreVersion": {
+                  "links": {
+                    "self": "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations/\(Self.localizationId)/relationships/appStoreVersion",
+                    "related": "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations/\(Self.localizationId)/appStoreVersion"
+                  }
+                }
+              }
+            }
+          ]
+        }
+        """
+    }
+}
+
+// MARK: - Helpers
+
+private func makeAppsWorker(transport: TestHTTPTransport) async throws -> AppsWorker {
+    let client = await HTTPClient(
+        jwtService: try TestFactory.makeJWTService(),
+        baseURL: "https://api.example.test",
+        transport: transport,
+        maxRetries: 1
+    )
+    return AppsWorker(client: client)
+}
+
+private func resultText(_ result: CallTool.Result) -> String {
+    result.content.compactMap { content in
+        if case .text(let text, _, _) = content {
+            return text
+        }
+        return nil
+    }.joined(separator: "\n")
+}
+
+private func jsonObject(_ result: CallTool.Result) throws -> [String: Any] {
+    let data = Data(resultText(result).utf8)
+    let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    return try #require(object)
+}
+
+private func metadataLocalizationObject(_ result: CallTool.Result) throws -> [String: Any] {
+    let object = try jsonObject(result)
+    return try #require(object["localization"] as? [String: Any])
+}


### PR DESCRIPTION
## Summary

Every tool that reads version-level App Store metadata fails for all apps and all versions, even when passed a `version_id` the server's own list tools just returned. `apps_get_metadata` and `apps_list_localizations` are effectively dead, so the keyword field, description, promotional text, and "What's New" (which live only on `appStoreVersionLocalizations`) cannot be read back at all.

## Root cause

One-line: the two relationship guards require a JSON:API resource linkage that App Store Connect only serializes when the request sends `include=`, so on the default response shape the parsed id is absent and the guard treats "absent" as "mismatch."

`versionBelongsToApp()` and `localizationBelongsToVersion()` in `AppsWorker+Handlers.swift` gate the read paths on:

- `version.relationships.app.data.id == appId`
- `localization.relationships.appStoreVersion.data.id == versionId`

App Store Connect only includes a relationship's `data` linkage when the request explicitly asks for it via `include=app` / `include=appStoreVersion`. These read paths do not send `include=`, so Apple returns a links-only relationship:

```json
"app": {
  "links": {
    "self": ".../relationships/app",
    "related": ".../app"
  }
}
```

There is no `data` member, so the parsed id is absent. The guards' `guard let ... else { return false }` then treated the absent linkage as a mismatch and rejected every response, producing:

- `apps_get_metadata` -> `Apple returned a localization outside version '<id>' context`
- `apps_list_localizations` -> `Version '<id>' does not belong to app '<id>'`

App-level reads (`app_info_list` via `appInfoLocalizations`) and `apps_list_versions` / `apps_get_details` were unaffected because they do not hit these guards, which is why the failure was isolated to the version-localization code path.

## Reproduction

Against a live account:

```
apps_get_metadata(app_id="<app>")
  -> Error: Apple returned a localization outside version '<version>' context
apps_get_metadata(app_id="<app>", version_id="<valid-version>", locale="en-US")
  -> same error
apps_list_localizations(app_id="<app>", version_id="<valid-version>")
  -> Error: Version '<version>' does not belong to app '<app>'
```

The `<valid-version>` id in each case was returned by `apps_list_versions` / `app_versions_list` moments earlier.

## Fix

Treat an absent linkage as "cannot verify, allow" and reject only on a positive mismatch (linkage present but pointing at a different id). The sub-resources are fetched under `/appStoreVersions/{id}/appStoreVersionLocalizations` and the version is fetched by id, so the URL already scopes them; the guard stays meaningful for the `include=` case without producing false negatives on the default response shape. The change is `return false` -> `return true` in the `else` branch of each guard, plus explaining comments.

## Tests

Adds `AppsMetadataRelationshipGuardTests`, which drives both `apps_get_metadata` and `apps_list_localizations` through a recorded App Store Connect response whose relationship linkage is omitted (the default Apple shape) and asserts the tools succeed and return the metadata (e.g. the `keywords` field).

These tests fail before the change (guard fires, `isError == true`) and pass after. All fixtures use dummy UUIDs; no real ids are committed.

The existing `AppsMetadataGetSelectionTests` continue to pass: their fixtures include the linkage, so the positive-match path is still covered.

`swift test` -> all tests pass (1168 tests / 108 suites, including the 2 new ones).

## Notes

- No API contract change; no new `include=` params were added (the smaller, safer fix, since the URL already scopes the resource).
- No credentials, keys, or real resource ids are included in the diff or fixtures.
