### PR TITLE
Release v4.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,25 +6,59 @@ on:
     tags: ['v*']
   pull_request:
     branches: [main, develop]
+  schedule:
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' || github.ref == 'refs/heads/develop') && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/develop' }}
 
 jobs:
-  build-and-test:
-    name: Build & Test
-    runs-on: macos-15
-    timeout-minutes: 20
+  promotion-lineage:
+    name: Promotion Lineage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'refs/heads/main' || github.ref }}
+
+      - name: Reject forced protected branch updates
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && github.event.forced
+        run: |
+          echo 'Protected branch history must not be force-pushed.' >&2
+          exit 1
+
+      - name: Validate main promotion source
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          CURRENT_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$HEAD_REF" != "develop" || "$HEAD_REPOSITORY" != "$CURRENT_REPOSITORY" ]]; then
+            echo "Pull requests into main must come from this repository's develop branch." >&2
+            exit 1
+          fi
+
+          git cat-file -e "$BASE_SHA^{commit}"
+          git cat-file -e "$HEAD_SHA^{commit}"
+          if ! git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"; then
+            echo "develop must contain the current main base before promotion." >&2
+            exit 1
+          fi
 
       - name: Validate release tag
         if: startsWith(github.ref, 'refs/tags/')
@@ -43,9 +77,19 @@ jobs:
             exit 1
           fi
 
+          tag_subject="$(git for-each-ref --format='%(contents:subject)' "refs/tags/$tag")"
+          if [[ "$tag_subject" != "$tag" ]]; then
+            echo "Annotated tag subject must exactly match the tag name: $tag" >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           tag_commit="$(git rev-parse "refs/tags/$tag^{commit}")"
-          if ! git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main; then
-            echo "Release tag commit must be an ancestor of origin/main: $tag_commit" >&2
+          main_commit="$(git rev-parse refs/remotes/origin/main)"
+          if [[ "$tag_commit" != "$main_commit" ]]; then
+            echo "Release tag must point to the current origin/main commit." >&2
+            echo "tag:  $tag_commit" >&2
+            echo "main: $main_commit" >&2
             exit 1
           fi
 
@@ -61,9 +105,14 @@ jobs:
             echo "README must contain the release Mint pin: $readme_pin" >&2
             exit 1
           fi
-          if grep -Eo 'mint install zelentsov-dev/asc-mcp@v[0-9]+\.[0-9]+\.[0-9]+' README.md \
-            | grep -Fvxq "$readme_pin"; then
-            echo "README contains a stale Mint release pin; every release pin must use $tag" >&2
+          stale_pin="$(
+            grep -Eo 'mint install zelentsov-dev/asc-mcp@v[0-9]+\.[0-9]+\.[0-9]+' README.md \
+              | grep -Fvx "$readme_pin" \
+              | head -n 1 \
+              || true
+          )"
+          if [[ -n "$stale_pin" ]]; then
+            echo "README contains a stale Mint release pin: $stale_pin" >&2
             exit 1
           fi
 
@@ -77,55 +126,146 @@ jobs:
             }
             END { exit(found ? 0 : 1) }
           ' CHANGELOG.md; then
-            echo "CHANGELOG.md must contain a section for [$version]" >&2
+            echo "CHANGELOG.md must contain a dated section for [$version]" >&2
             exit 1
           fi
+
+  tests:
+    name: Tests
+    needs: promotion-lineage
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'refs/heads/main' || github.ref }}
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
-      - name: Build
-        run: swift build --disable-automatic-resolution
+      - name: Run tests
+        shell: bash
+        run: |
+          set -o pipefail
+          swift test --disable-automatic-resolution 2>&1 \
+            | tee "$RUNNER_TEMP/asc_mcp_tests.log"
 
-      - name: Release build
-        run: swift build --disable-automatic-resolution -c release 2>&1 | tee /tmp/asc_mcp_release.log
+      - name: Publish test summary
+        if: always()
+        shell: bash
+        env:
+          TEST_JOB_STATUS: ${{ job.status }}
+        run: |
+          {
+            echo '## Tests'
+            echo "- Status: $TEST_JOB_STATUS"
+            echo "- Ref: $GITHUB_REF_NAME"
+            echo "- Run attempt: $GITHUB_RUN_ATTEMPT"
+            if [[ -s "$RUNNER_TEMP/asc_mcp_tests.log" ]]; then
+              echo '<details><summary>Failure indicators</summary>'
+              echo
+              echo '```text'
+              grep -Ei 'error:|failed|failure|✘' "$RUNNER_TEMP/asc_mcp_tests.log" \
+                | tail -n 40 \
+                || true
+              echo '```'
+              echo '</details>'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-log-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/asc_mcp_tests.log
+          if-no-files-found: warn
+          retention-days: 30
+
+  release-contract:
+    name: Release & Apple Contract
+    needs: promotion-lineage
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'refs/heads/main' || github.ref }}
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+
+      - name: Build release binary
+        shell: bash
+        run: |
+          set -o pipefail
+          swift build --disable-automatic-resolution -c release 2>&1 \
+            | tee "$RUNNER_TEMP/asc_mcp_release.log"
 
       - name: Fail on release warnings
-        run: '! grep -q "warning:" /tmp/asc_mcp_release.log'
+        shell: bash
+        run: |
+          if grep -n 'warning:' "$RUNNER_TEMP/asc_mcp_release.log"; then
+            echo 'Release build emitted compiler warnings.' >&2
+            exit 1
+          fi
+
+      - name: Verify release binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_version="$(awk -F'"' '/static let current =/ { print $2 }' Sources/asc-mcp/Core/ServerVersion.swift)"
+          test "$(.build/release/asc-mcp --version)" = "asc-mcp $expected_version"
 
       - name: OpenAPI coverage tooling smoke
         run: |
-          swift run --disable-automatic-resolution asc-mcp openapi-coverage \
+          .build/release/asc-mcp openapi-coverage \
             --spec Tests/ASCMCPTests/Fixtures/openapi_minimal.oas.json \
-            --output /tmp/asc_openapi_coverage.md \
+            --output "$RUNNER_TEMP/asc_openapi_coverage.md" \
             --generated-at 2026-05-07
-          test -s /tmp/asc_openapi_coverage.md
+          test -s "$RUNNER_TEMP/asc_openapi_coverage.md"
 
       - name: App Store Connect operation contract
+        shell: bash
         run: |
-          rm -rf /tmp/asc_openapi_contract
-          mkdir -p /tmp/asc_openapi_contract
+          set -euo pipefail
+
+          contract_directory="$RUNNER_TEMP/asc_openapi_contract"
+          rm -rf "$contract_directory"
+          mkdir -p "$contract_directory"
           curl --fail --show-error --silent --location \
             --proto '=https' --proto-redir '=https' \
             --connect-timeout 15 --max-time 120 \
             --retry 3 --retry-delay 2 --retry-all-errors \
-            --output /tmp/asc_openapi_contract/spec.zip \
+            --output "$contract_directory/spec.zip" \
             https://developer.apple.com/sample-code/app-store-connect/app-store-connect-openapi-specification.zip
-          spec_entry="$(unzip -Z1 /tmp/asc_openapi_contract/spec.zip | grep -E '(^|/)openapi\.oas[^/]*\.json$')"
+          shasum -a 256 "$contract_directory/spec.zip" \
+            > "$contract_directory/specification.sha256"
+
+          spec_entry="$(
+            unzip -Z1 "$contract_directory/spec.zip" \
+              | grep -E '(^|/)openapi\.oas[^/]*\.json$'
+          )"
           test -n "$spec_entry"
-          test "$(echo "$spec_entry" | grep -c .)" -eq 1
-          unzip -p /tmp/asc_openapi_contract/spec.zip "$spec_entry" \
-            > /tmp/asc_openapi_contract/openapi.oas.json
-          swift run --disable-automatic-resolution asc-mcp openapi-contract-check \
-            --spec /tmp/asc_openapi_contract/openapi.oas.json \
-            --json-output /tmp/asc_openapi_contract/report.json \
-            --markdown-output /tmp/asc_openapi_contract/report.md \
+          test "$(printf '%s\n' "$spec_entry" | grep -c .)" -eq 1
+          unzip -p "$contract_directory/spec.zip" "$spec_entry" \
+            > "$contract_directory/openapi.oas.json"
+
+          .build/release/asc-mcp openapi-contract-check \
+            --spec "$contract_directory/openapi.oas.json" \
+            --json-output "$contract_directory/report.json" \
+            --markdown-output "$contract_directory/report.md" \
             --strict
-          mkdir -p /tmp/asc_openapi_contract/relocated
-          cp .build/release/asc-mcp /tmp/asc_openapi_contract/relocated/
-          cp -R .build/release/asc-mcp_asc-mcp.bundle /tmp/asc_openapi_contract/relocated/
-          /tmp/asc_openapi_contract/relocated/asc-mcp openapi-contract-check \
-            --spec /tmp/asc_openapi_contract/openapi.oas.json \
+
+          mkdir -p "$contract_directory/relocated"
+          cp .build/release/asc-mcp "$contract_directory/relocated/"
+          cp -R .build/release/asc-mcp_asc-mcp.bundle "$contract_directory/relocated/"
+          "$contract_directory/relocated/asc-mcp" openapi-contract-check \
+            --spec "$contract_directory/openapi.oas.json" \
             --strict
 
       - name: Verify generated OpenAPI coverage
@@ -133,54 +273,230 @@ jobs:
         run: |
           set -euo pipefail
 
+          contract_directory="$RUNNER_TEMP/asc_openapi_contract"
           generated_at="$(awk '$1 == "Generated:" { print $2; exit }' ASC-OPENAPI-COVERAGE-GENERATED.md)"
           if [[ ! "$generated_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
-            echo "ASC-OPENAPI-COVERAGE-GENERATED.md must contain a valid Generated date" >&2
+            echo 'ASC-OPENAPI-COVERAGE-GENERATED.md must contain a valid Generated date.' >&2
             exit 1
           fi
 
-          swift run --disable-automatic-resolution asc-mcp openapi-coverage \
-            --spec /tmp/asc_openapi_contract/openapi.oas.json \
-            --output /tmp/asc_openapi_contract/coverage.md \
+          .build/release/asc-mcp openapi-coverage \
+            --spec "$contract_directory/openapi.oas.json" \
+            --output "$contract_directory/coverage.md" \
             --generated-at "$generated_at"
           diff --unified ASC-OPENAPI-COVERAGE-GENERATED.md \
-            /tmp/asc_openapi_contract/coverage.md
+            "$contract_directory/coverage.md"
 
-      - name: Upload operation contract report
+      - name: Upload operation contract reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: app-store-connect-operation-contract-${{ github.run_attempt }}
+          name: app-store-connect-operation-contract-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
-            /tmp/asc_openapi_contract/report.json
-            /tmp/asc_openapi_contract/report.md
-            /tmp/asc_mcp_release.log
+            ${{ runner.temp }}/asc_openapi_contract/report.json
+            ${{ runner.temp }}/asc_openapi_contract/report.md
+            ${{ runner.temp }}/asc_openapi_contract/specification.sha256
+            ${{ runner.temp }}/asc_mcp_release.log
           if-no-files-found: warn
           retention-days: 30
 
-      - name: Test
-        run: swift test --disable-automatic-resolution
-
-      - name: App Store Connect release contract
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          /tmp/asc_openapi_contract/relocated/asc-mcp openapi-contract-check \
-            --spec /tmp/asc_openapi_contract/openapi.oas.json \
-            --strict
-
-      - name: Publish job summary
+      - name: Publish contract summary
         if: always()
         shell: bash
         env:
-          CI_JOB_STATUS: ${{ job.status }}
-          CI_REF_NAME: ${{ github.ref_name }}
-          CI_RUN_ATTEMPT: ${{ github.run_attempt }}
+          CONTRACT_JOB_STATUS: ${{ job.status }}
         run: |
           printf '%s\n' \
-            '## asc-mcp CI' \
-            "- Status: $CI_JOB_STATUS" \
-            "- Ref: $CI_REF_NAME" \
-            "- Run attempt: $CI_RUN_ATTEMPT" \
+            '## Release & Apple Contract' \
+            "- Status: $CONTRACT_JOB_STATUS" \
+            "- Ref: $GITHUB_REF_NAME" \
+            "- Run attempt: $GITHUB_RUN_ATTEMPT" \
             '- Contract mode: strict' \
-            '- Artifact includes contract reports and the release build log.' \
+            '- Artifacts: contract reports and release build log' \
             >> "$GITHUB_STEP_SUMMARY"
+
+  publish-release:
+    name: Mint MCP Smoke & Publish Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [promotion-lineage, tests, release-contract]
+    runs-on: macos-15
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+
+      - name: Install tagged release through Mint
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew install mint
+          mint install "zelentsov-dev/asc-mcp@$GITHUB_REF_NAME" --force
+
+      - name: Run installed MCP smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          test "$("$HOME/.mint/bin/asc-mcp" --version)" = "asc-mcp $version"
+          python3 Scripts/ci/mcp_stdio_smoke.py \
+            --binary "$HOME/.mint/bin/asc-mcp" \
+            --expected-version "$version" \
+            --expected-tool-count 502 \
+            --expected-prefix xcode_cloud_ \
+            --expected-prefix-count 42 \
+            --error-tool xcode_cloud_workflows_create \
+            | tee "$RUNNER_TEMP/mcp-smoke.json"
+
+      - name: Prepare release notes
+        id: notes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${GITHUB_REF_NAME#v}"
+          heading="## [$version]"
+          notes_path="$RUNNER_TEMP/release-notes.md"
+          awk -v heading="$heading" '
+            index($0, heading " - ") == 1 { capture = 1; next }
+            capture && /^## \[/ { exit }
+            capture { print }
+          ' CHANGELOG.md > "$notes_path"
+          if ! grep -q '[^[:space:]]' "$notes_path"; then
+            echo "Unable to extract release notes for $GITHUB_REF_NAME." >&2
+            exit 1
+          fi
+          echo "path=$notes_path" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release smoke evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-smoke-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/mcp-smoke.json
+            ${{ steps.notes.outputs.path }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Create or validate draft release
+        id: draft
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NOTES_PATH: ${{ steps.notes.outputs.path }}
+        run: |
+          set -euo pipefail
+
+          releases_path="$RUNNER_TEMP/releases.json"
+          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" > "$releases_path"
+          release_count="$(jq --arg tag "$GITHUB_REF_NAME" '[.[] | select(.tag_name == $tag)] | length' "$releases_path")"
+          if [[ "$release_count" -gt 1 ]]; then
+            echo "Multiple releases use tag $GITHUB_REF_NAME." >&2
+            exit 1
+          fi
+
+          if [[ "$release_count" -eq 1 ]]; then
+            release_id="$(jq -r --arg tag "$GITHUB_REF_NAME" '.[] | select(.tag_name == $tag) | .id' "$releases_path")"
+            release_name="$(jq -r --arg tag "$GITHUB_REF_NAME" '.[] | select(.tag_name == $tag) | .name' "$releases_path")"
+            is_draft="$(jq -r --arg tag "$GITHUB_REF_NAME" '.[] | select(.tag_name == $tag) | .draft' "$releases_path")"
+            is_prerelease="$(jq -r --arg tag "$GITHUB_REF_NAME" '.[] | select(.tag_name == $tag) | .prerelease' "$releases_path")"
+            if [[ "$release_name" != "$GITHUB_REF_NAME" || "$is_prerelease" != "false" ]]; then
+              echo "Existing release metadata does not match $GITHUB_REF_NAME." >&2
+              exit 1
+            fi
+            echo "release-id=$release_id" >> "$GITHUB_OUTPUT"
+            if [[ "$is_draft" == "false" ]]; then
+              if ! jq -e \
+                --arg tag "$GITHUB_REF_NAME" \
+                --rawfile body "$NOTES_PATH" \
+                '.[] | select(.tag_name == $tag) | .body == $body' \
+                "$releases_path" > /dev/null; then
+                echo "Published release notes differ from CHANGELOG.md." >&2
+                exit 1
+              fi
+              echo 'already-published=true' >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            gh release edit "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file "$NOTES_PATH" \
+              --prerelease=false
+            exit 0
+          fi
+
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --draft \
+            --title "$GITHUB_REF_NAME" \
+            --target main \
+            --notes-file "$NOTES_PATH"
+
+          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" > "$releases_path"
+          release_id="$(jq -r --arg tag "$GITHUB_REF_NAME" '.[] | select(.tag_name == $tag) | .id' "$releases_path")"
+          if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
+            echo "Unable to resolve the draft release ID for $GITHUB_REF_NAME." >&2
+            exit 1
+          fi
+          echo "release-id=$release_id" >> "$GITHUB_OUTPUT"
+
+      - name: Verify draft release
+        if: steps.draft.outputs.already-published != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NOTES_PATH: ${{ steps.notes.outputs.path }}
+          RELEASE_ID: ${{ steps.draft.outputs.release-id }}
+        run: |
+          set -euo pipefail
+
+          release_path="$RUNNER_TEMP/draft-release.json"
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > "$release_path"
+          jq -e \
+            --arg tag "$GITHUB_REF_NAME" \
+            --rawfile body "$NOTES_PATH" \
+            '.tag_name == $tag and
+             .name == $tag and
+             .body == $body and
+             .draft == true and
+             .prerelease == false and
+             .target_commitish == "main"' \
+            "$release_path" > /dev/null
+
+      - name: Publish immutable release
+        if: steps.draft.outputs.already-published != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+
+      - name: Verify published release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NOTES_PATH: ${{ steps.notes.outputs.path }}
+          RELEASE_ID: ${{ steps.draft.outputs.release-id }}
+        run: |
+          set -euo pipefail
+
+          release_path="$RUNNER_TEMP/published-release.json"
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > "$release_path"
+          jq -e \
+            --arg tag "$GITHUB_REF_NAME" \
+            --rawfile body "$NOTES_PATH" \
+            '.tag_name == $tag and
+             .name == $tag and
+             .body == $body and
+             .draft == false and
+             .prerelease == false and
+             .target_commitish == "main"' \
+            "$release_path" > /dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.1] - 2026-07-21
+
+### Changed
+
+- Split CI into stable promotion-lineage, test, and Release/App Store Connect contract gates so independent verification runs in parallel and failures identify the affected layer.
+- Release tags now require an annotated exact SemVer tag on the current `main` commit; superseded pull-request and `develop` runs may be cancelled, while `main` and release-tag runs always finish.
+- Tag CI now installs the tagged source through Mint, performs real MCP `initialize`, `tools/list`, and structured-error checks, and publishes a GitHub Release only after every required gate succeeds.
+- Weekly and manually dispatched CI runs monitor the pinned Apple App Store Connect OpenAPI contract even when the repository has no code changes.
+
+### Fixed
+
+- Test failures are evaluated before the slower release contract finishes and retain a downloadable log with a concise failure summary.
+- Release validation uses the already-built release binary instead of rebuilding through repeated `swift run` commands.
+- Release notes are generated from the shipped changelog section, and publishing follows a draft-first flow compatible with immutable GitHub Releases.
+
+### Compatibility
+
+- No MCP tool, input, output, worker filter, Apple operation mapping, or runtime behavior changes in this patch release; the catalog remains at 502 tools.
+
 ## [4.1.0] - 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 ```bash
 # 1. Install via Mint
 brew install mint
-mint install zelentsov-dev/asc-mcp@v4.1.0
+mint install zelentsov-dev/asc-mcp@v4.1.1
 
 # 2. Add to Claude Code with env vars (simplest setup)
 claude mcp add asc-mcp \
@@ -88,7 +88,7 @@ Or use a JSON config file — see [Configuration](#configuration) below.
 brew install mint
 
 # Install asc-mcp from GitHub
-mint install zelentsov-dev/asc-mcp@v4.1.0
+mint install zelentsov-dev/asc-mcp@v4.1.1
 
 # Register in Claude Code
 claude mcp add asc-mcp -- ~/.mint/bin/asc-mcp
@@ -99,13 +99,13 @@ To install a specific branch or tag:
 ```bash
 mint install zelentsov-dev/asc-mcp@main      # main branch
 mint install zelentsov-dev/asc-mcp@develop    # develop branch
-mint install zelentsov-dev/asc-mcp@v4.1.0    # specific tag
+mint install zelentsov-dev/asc-mcp@v4.1.1    # specific tag
 ```
 
 To update to the latest version:
 
 ```bash
-mint install zelentsov-dev/asc-mcp@v4.1.0 --force
+mint install zelentsov-dev/asc-mcp@v4.1.1 --force
 ```
 
 ### Migrating from v4.0.x
@@ -451,7 +451,7 @@ swift run asc-mcp openapi-contract-check \
 
 The manifest is pinned to Apple API 4.4.1 by version, SHA-256, path count, and operation count. It currently maps 476 Apple operations, explicitly defers 424, and scopes out 363, covering all 1,263 operations without overlap. CI fails when the Apple document changes, a mapped operation moves or disappears, a public tool or worker drifts from the manifest, an input field loses its binding, response lineage becomes invalid, or a deferred decision expires. Unexposed optional Apple parameters are warnings so they remain visible in the generated backlog.
 
-Manifest schema v2 also accounts for every optional Apple query and request-body input as publicly bound, internally controlled, intentionally omitted with a reviewed reason, or still unclassified. The checked-in `optionalInputCoveragePin` records the exact current totals and a SHA-256 digest of the sorted input identities and dispositions; `--strict` rejects a missing pin or any count- or identity-level drift. The pin makes phased remediation auditable and regression-safe, but it is not a claim that every optional Apple input is already public. The v4.1.0 pin is 2,905 total: 1,103 bound, 40 internally controlled, 1,762 intentionally omitted, and 0 unclassified. Its identity SHA-256 is `733827d5ad0fc66d541bdd51922567a7f7cd7a941b882ca2e89a0ea6d6a1cfee`.
+Manifest schema v2 also accounts for every optional Apple query and request-body input as publicly bound, internally controlled, intentionally omitted with a reviewed reason, or still unclassified. The checked-in `optionalInputCoveragePin` records the exact current totals and a SHA-256 digest of the sorted input identities and dispositions; `--strict` rejects a missing pin or any count- or identity-level drift. The pin makes phased remediation auditable and regression-safe, but it is not a claim that every optional Apple input is already public. The v4.1.1 pin is 2,905 total: 1,103 bound, 40 internally controlled, 1,762 intentionally omitted, and 0 unclassified. Its identity SHA-256 is `733827d5ad0fc66d541bdd51922567a7f7cd7a941b882ca2e89a0ea6d6a1cfee`.
 
 `--strict` is the merge- and tag-time release gate. Every declared `target` or `broken` tool remains an error in reports, and a regression test pins their exact state. The current baseline has no `target` or `broken` implementations and no implementation drift, so any implementation that leaves `asBuilt`, any structural contract error, or any optional-input coverage drift blocks both merges and releases. `--structural-strict` remains available only for local phased remediation work.
 

--- a/Scripts/ci/mcp_stdio_smoke.py
+++ b/Scripts/ci/mcp_stdio_smoke.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+class SmokeFailure(RuntimeError):
+    pass
+
+
+class JSONRPCClient:
+    def __init__(self, process: subprocess.Popen[bytes]) -> None:
+        if process.stdin is None or process.stdout is None:
+            raise SmokeFailure("MCP process pipes are unavailable")
+        self.process = process
+        self.stdin = process.stdin
+        self.stdout = process.stdout
+        self.buffer = bytearray()
+
+    def send(self, message: dict[str, Any]) -> None:
+        payload = json.dumps(message, separators=(",", ":")).encode("utf-8") + b"\n"
+        self.stdin.write(payload)
+        self.stdin.flush()
+
+    def receive(self, response_id: int, timeout: float) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        while True:
+            line = self._readline(deadline)
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise SmokeFailure(f"MCP stdout contained invalid JSON: {line[:200]!r}") from error
+            if not isinstance(payload, dict):
+                raise SmokeFailure("MCP stdout JSON-RPC payload is not an object")
+            if payload.get("id") == response_id:
+                return payload
+
+    def _readline(self, deadline: float) -> str:
+        while True:
+            newline = self.buffer.find(b"\n")
+            if newline >= 0:
+                raw = bytes(self.buffer[:newline])
+                del self.buffer[: newline + 1]
+                return raw.rstrip(b"\r").decode("utf-8")
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise SmokeFailure("Timed out waiting for an MCP JSON-RPC response")
+
+            ready, _, _ = select.select([self.stdout.fileno()], [], [], remaining)
+            if not ready:
+                continue
+            chunk = os.read(self.stdout.fileno(), 65536)
+            if not chunk:
+                raise SmokeFailure(
+                    f"MCP process closed stdout unexpectedly with exit code {self.process.poll()}"
+                )
+            self.buffer.extend(chunk)
+
+
+def non_negative_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be an integer") from error
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be zero or greater")
+    return parsed
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Exercise an asc-mcp binary over MCP stdio")
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--expected-tool-count", required=True, type=non_negative_integer)
+    parser.add_argument("--expected-prefix", required=True)
+    parser.add_argument("--expected-prefix-count", required=True, type=non_negative_integer)
+    parser.add_argument("--error-tool", required=True)
+    return parser.parse_args()
+
+
+def response_result(payload: dict[str, Any], operation: str) -> dict[str, Any]:
+    if "error" in payload:
+        raise SmokeFailure(f"{operation} returned a JSON-RPC error: {payload['error']!r}")
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        raise SmokeFailure(f"{operation} did not return an object result")
+    return result
+
+
+def validate_initialize(result: dict[str, Any], expected_version: str) -> str:
+    server_info = result.get("serverInfo")
+    if not isinstance(server_info, dict):
+        raise SmokeFailure("initialize result is missing serverInfo")
+    version = server_info.get("version")
+    if version != expected_version:
+        raise SmokeFailure(f"expected server version {expected_version!r}, received {version!r}")
+    return version
+
+
+def validate_tools(
+    result: dict[str, Any],
+    expected_count: int,
+    expected_prefix: str,
+    expected_prefix_count: int,
+    error_tool: str,
+) -> tuple[list[str], int]:
+    tools = result.get("tools")
+    if not isinstance(tools, list):
+        raise SmokeFailure("tools/list result is missing the tools array")
+    if result.get("nextCursor") is not None:
+        raise SmokeFailure("tools/list unexpectedly returned a pagination cursor")
+
+    names: list[str] = []
+    for index, tool in enumerate(tools):
+        if not isinstance(tool, dict) or not isinstance(tool.get("name"), str):
+            raise SmokeFailure(f"tools[{index}] is missing a string name")
+        names.append(tool["name"])
+
+    if len(names) != expected_count:
+        raise SmokeFailure(f"expected {expected_count} tools, received {len(names)}")
+
+    duplicate_names = sorted({name for name in names if names.count(name) > 1})
+    if duplicate_names:
+        raise SmokeFailure(f"duplicate tool names: {duplicate_names[:10]!r}")
+
+    prefix_count = sum(name.startswith(expected_prefix) for name in names)
+    if prefix_count != expected_prefix_count:
+        raise SmokeFailure(
+            f"expected {expected_prefix_count} tools with prefix {expected_prefix!r}, "
+            f"received {prefix_count}"
+        )
+    if error_tool not in names:
+        raise SmokeFailure(f"error tool {error_tool!r} is absent from tools/list")
+    return names, prefix_count
+
+
+def validate_error_result(result: dict[str, Any], error_tool: str) -> None:
+    if result.get("isError") is not True:
+        raise SmokeFailure(f"{error_tool} with empty arguments did not return isError=true")
+
+    structured = result.get("structuredContent")
+    if not isinstance(structured, dict):
+        raise SmokeFailure(f"{error_tool} error is missing structuredContent")
+    if structured.get("success") is not False:
+        raise SmokeFailure(f"{error_tool} structuredContent.success is not false")
+    if not isinstance(structured.get("error"), str) or not structured["error"]:
+        raise SmokeFailure(f"{error_tool} structuredContent.error is missing or empty")
+    if "details" not in structured:
+        raise SmokeFailure(f"{error_tool} structuredContent.details is missing")
+
+    content = result.get("content")
+    if not isinstance(content, list):
+        raise SmokeFailure(f"{error_tool} error is missing content")
+    text_blocks = [
+        block.get("text")
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+    if not text_blocks or not isinstance(text_blocks[-1], str):
+        raise SmokeFailure(f"{error_tool} error has no final text block")
+    try:
+        mirror = json.loads(text_blocks[-1])
+    except json.JSONDecodeError as error:
+        raise SmokeFailure(f"{error_tool} final text block is not a JSON mirror") from error
+    if mirror != structured:
+        raise SmokeFailure(f"{error_tool} structuredContent and final JSON mirror differ")
+
+
+def close_process(process: subprocess.Popen[bytes]) -> int:
+    if process.stdin is not None and not process.stdin.closed:
+        try:
+            process.stdin.close()
+        except BrokenPipeError:
+            pass
+    try:
+        exit_code = process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.terminate()
+        try:
+            exit_code = process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            exit_code = process.wait(timeout=5)
+    if process.stdout is not None and not process.stdout.closed:
+        process.stdout.close()
+    return exit_code
+
+
+def run_smoke(arguments: argparse.Namespace) -> dict[str, Any]:
+    binary = Path(arguments.binary).expanduser().resolve()
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        raise SmokeFailure(f"binary is not an executable file: {binary}")
+
+    with tempfile.TemporaryDirectory(prefix="asc-mcp-stdio-smoke-") as directory:
+        smoke_directory = Path(directory)
+        key_path = smoke_directory / "AuthKey.p8"
+        config_path = smoke_directory / "companies.json"
+        subprocess.run(
+            [
+                "openssl",
+                "genpkey",
+                "-algorithm",
+                "EC",
+                "-pkeyopt",
+                "ec_paramgen_curve:P-256",
+                "-out",
+                str(key_path),
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        config_path.write_text(
+            json.dumps(
+                {
+                    "companies": [
+                        {
+                            "id": "ci-smoke",
+                            "name": "CI Smoke",
+                            "key_id": "SMOKEKEY",
+                            "issuer_id": "00000000-0000-0000-0000-000000000000",
+                            "key_path": str(key_path),
+                        }
+                    ]
+                },
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+
+        environment = os.environ.copy()
+        environment["ASC_MCP_COMPANIES"] = str(config_path)
+        stderr_path = smoke_directory / "stderr.log"
+        process: subprocess.Popen[bytes] | None = None
+        exit_code: int | None = None
+        try:
+            with stderr_path.open("wb") as stderr_file:
+                process = subprocess.Popen(
+                    [str(binary), "--companies", str(config_path)],
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=stderr_file,
+                    env=environment,
+                    bufsize=0,
+                )
+                client = JSONRPCClient(process)
+                client.send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {},
+                            "clientInfo": {"name": "asc-mcp-ci-smoke", "version": "1.0"},
+                        },
+                    }
+                )
+                initialize_result = response_result(client.receive(1, 30), "initialize")
+                version = validate_initialize(initialize_result, arguments.expected_version)
+
+                client.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+                client.send({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+                tools_result = response_result(client.receive(2, 30), "tools/list")
+                tool_names, prefix_count = validate_tools(
+                    tools_result,
+                    arguments.expected_tool_count,
+                    arguments.expected_prefix,
+                    arguments.expected_prefix_count,
+                    arguments.error_tool,
+                )
+
+                client.send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 3,
+                        "method": "tools/call",
+                        "params": {"name": arguments.error_tool, "arguments": {}},
+                    }
+                )
+                error_result = response_result(client.receive(3, 30), "tools/call")
+                validate_error_result(error_result, arguments.error_tool)
+                exit_code = close_process(process)
+                if exit_code != 0:
+                    raise SmokeFailure(f"MCP process exited with code {exit_code}")
+        except Exception as error:
+            if process is not None:
+                exit_code = close_process(process)
+            stderr_tail = stderr_path.read_text(encoding="utf-8", errors="replace")[-4000:]
+            if stderr_tail:
+                raise SmokeFailure(f"{error}; MCP stderr: {stderr_tail.strip()}") from error
+            raise
+
+    return {
+        "status": "ok",
+        "version": version,
+        "toolCount": len(tool_names),
+        "prefix": arguments.expected_prefix,
+        "prefixCount": prefix_count,
+        "errorTool": arguments.error_tool,
+        "structuredErrorVerified": True,
+    }
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        report = run_smoke(arguments)
+    except Exception as error:
+        print(
+            json.dumps(
+                {"status": "error", "error": str(error)},
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(report, separators=(",", ":"), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Sources/asc-mcp/Core/ServerVersion.swift
+++ b/Sources/asc-mcp/Core/ServerVersion.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 enum ServerVersion {
-    static let current = "4.1.0"
+    static let current = "4.1.1"
 }


### PR DESCRIPTION
## Summary

Promote the verified CI hardening patch from `develop` to `main`.

- stable parallel lineage, test, and Apple contract gates
- test and Apple-spec evidence artifacts
- exact-main annotated tag validation
- tagged Mint install plus real MCP stdio smoke
- changelog-backed draft-first GitHub Release publication
- weekly/manual Apple OpenAPI drift monitoring
- no MCP catalog or App Store Connect behavior changes; 502 tools remain

## Verified on develop

- PR #9 CI: green
- `develop` push CI run 29817910604: green
- `Promotion Lineage`: green
- `Tests`: green
- `Release & Apple Contract`: green

After this PR is green, repository branch/tag rules and immutable Releases will be enabled before the v4.1.1 tag is created.